### PR TITLE
Fix default arguments in reward method

### DIFF
--- a/hpsv3/inference.py
+++ b/hpsv3/inference.py
@@ -137,7 +137,7 @@ class HPSv3RewardInferencer():
         return batch
 
     @torch.inference_mode()
-    def reward(self, prompts, image_paths):
+    def reward(self, prompts=prompts, image_paths=image_paths):
         batch = self.prepare_batch(image_paths, prompts)
         rewards = self.model(
             return_dict=True,


### PR DESCRIPTION
Eliminate ambiguity in argument order; the original script does not work because prompts and image_paths are in the wrong order.